### PR TITLE
Remove unnecessary variable

### DIFF
--- a/src/Traits/Presentable.php
+++ b/src/Traits/Presentable.php
@@ -41,8 +41,7 @@ trait Presentable
     public function getPresenterAttribute()
     {
         if (is_null($this->presenterInstance)) {
-            $presenter = $this->presenter;
-            $this->presenterInstance = new $presenter($this);
+            $this->presenterInstance = (new $this->presenter($this));
         }
 
         return $this->presenterInstance;


### PR DESCRIPTION
The Presenter class can be instantiated in a single line without the need to store the presenter's FQCN as a variable